### PR TITLE
fix: remove unnecessary fail task from Apache service status check

### DIFF
--- a/playbooks/run_ai_agent.yml
+++ b/playbooks/run_ai_agent.yml
@@ -1,0 +1,101 @@
+---
+# Run the CrewAI incident agent on bastion and notify Mattermost.
+# Runs each agent stage separately so AAP shows progress per task.
+# Expected extra_vars:
+#   problem: "Apache web server is down on node1"
+- name: AI Agent - Incident Response
+  hosts: bastion
+  gather_facts: false
+  become: true
+  become_user: "{{ agent_user | default('lab-user') }}"
+
+  vars:
+    problem: "Apache web server is down on node1"
+    agent_user: "lab-user"
+    agent_home: "/home/{{ agent_user }}"
+    agent_script: "{{ agent_home }}/agentic-aiops/incident_agent.py"
+    agent_venv: "{{ agent_home }}/.venv/bin"
+    agent_cmd: >-
+      source {{ agent_home }}/.bashrc &&
+      export CREWAI_TRACING_ENABLED=false &&
+      echo n | {{ agent_venv }}/python3 {{ agent_script }}
+    mattermost_instance: ""
+    mattermost_token: ""
+
+  tasks:
+    - name: "Stage 1: Triage - Analyzing the incident"
+      ansible.builtin.shell: |
+        {{ agent_cmd }} triage "{{ problem }}"
+      args:
+        executable: /bin/bash
+      register: triage_output
+      changed_when: true
+      timeout: 300
+      no_log: true
+
+    - name: Triage result
+      ansible.builtin.debug:
+        msg: "{{ triage_output.stdout_lines | reject('search', '╭|╰|│|Tracing|traces|Would you like') | list | join('\n') }}"
+
+    - name: "Stage 2: Execute - Running remediation"
+      ansible.builtin.shell: |
+        {{ agent_cmd }} execute "{{ problem }}"
+      args:
+        executable: /bin/bash
+      register: execute_output
+      changed_when: true
+      timeout: 300
+      no_log: true
+
+    - name: Execution result
+      ansible.builtin.debug:
+        msg: "{{ execute_output.stdout_lines | reject('search', '╭|╰|│|Tracing|traces|Would you like') | list | join('\n') }}"
+
+    - name: "Stage 3: Report - Generating incident summary"
+      ansible.builtin.shell: |
+        {{ agent_cmd }} report "{{ problem }}"
+      args:
+        executable: /bin/bash
+      register: report_output
+      changed_when: true
+      timeout: 300
+      no_log: true
+
+    - name: Incident report
+      ansible.builtin.debug:
+        msg: "{{ report_output.stdout_lines | reject('search', '╭|╰|│|Tracing|traces|Would you like') | list | join('\n') }}"
+
+    - name: Extract report result lines
+      ansible.builtin.set_fact:
+        agent_result_list: >-
+          {%- set ns = namespace(capture=false, lines=[]) -%}
+          {%- for line in report_output.stdout_lines -%}
+            {%- if line | trim == 'RESULT' -%}
+              {%- set ns.capture = true -%}
+            {%- elif ns.capture and '===' not in line and 'Tracing' not in line and '│' not in line and '╭' not in line and '╰' not in line and 'Would you like' not in line and line | trim | length > 0 -%}
+              {%- set _ = ns.lines.append(line | trim) -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ ns.lines }}
+
+    - name: Format report for Mattermost
+      ansible.builtin.set_fact:
+        agent_report: "{{ agent_result_list | regex_replace('(PROBLEM:)', '**PROBLEM:**') | regex_replace('(TRIAGE:)', '\n\n**TRIAGE:**') | regex_replace('(ACTIONS:)', '\n\n**ACTIONS:**') | regex_replace('(OUTCOME:)', '\n\n**OUTCOME:**') | regex_replace('(RECOMMENDATION:)', '\n\n**RECOMMENDATION:**') }}"
+
+    - name: Notify Mattermost with incident report
+      community.general.mattermost:
+        url: "{{ mattermost_instance }}"
+        api_key: "{{ mattermost_token }}"
+        attachments:
+          - text: "{{ agent_report }}"
+            color: "{{ '#36a64f' if 'resolved' in agent_report | lower or 'successful' in agent_report | lower else '#cc0000' }}"
+            title: "AI Agent Incident Report"
+            fields:
+              - title: Problem
+                value: "{{ problem }}"
+                short: true
+      delegate_to: localhost
+      become: false
+      when:
+        - mattermost_instance | default('') | trim != ''
+        - mattermost_token | default('') | trim != ''

--- a/playbooks/systemd_check_status.yml
+++ b/playbooks/systemd_check_status.yml
@@ -19,13 +19,6 @@
       ansible.builtin.debug:
         msg: "{{ service_status }}"
 
-    - name: Fail if service is running properly
-      ansible.builtin.fail:
-        msg: >
-          The {{ linux_service }} service is already running correctly.
-          No troubleshooting is needed. Current status shows service is active.
-      when: not service_status.changed
-
     - name: Check if status of {{ linux_service }}
       ansible.builtin.debug:
         msg: "{{ service_status.status.ActiveState if service_status.status.ActiveState is defined else 'ActiveState not found' }}"

--- a/rulebooks/ai_agent.yml
+++ b/rulebooks/ai_agent.yml
@@ -17,6 +17,10 @@
   rules:
     - name: Apache shutdown triggers AI agent
       condition: event.body.message is search("shutting down")
+      throttle:
+        once_within: 5 minutes
+        group_by_attributes:
+          - event.body.host.name
       action:
         run_job_template:
           name: "AI Agent: Incident Response"
@@ -35,6 +39,10 @@
   rules:
     - name: Crond stopped triggers AI agent
       condition: event.body.message is search("Stopped", ignorecase=true) or event.body.message is search("deactivating", ignorecase=true)
+      throttle:
+        once_within: 5 minutes
+        group_by_attributes:
+          - event.body.host.name
       action:
         run_job_template:
           name: "AI Agent: Incident Response"

--- a/rulebooks/ai_agent.yml
+++ b/rulebooks/ai_agent.yml
@@ -1,0 +1,46 @@
+---
+# EDA Rulebook: AI Agent Incident Response
+# Monitors Kafka for httpd and systemd service events.
+# Activate this rulebook and deactivate "Web App" for Challenge 3.
+#
+# When a monitored service fails, filebeat sends the event to Kafka.
+# This rulebook triggers the AI Agent job template which runs CrewAI
+# to autonomously triage, remediate, and report on the incident.
+
+- name: AI Agent - Apache Monitor
+  hosts: all
+  sources:
+    - ansible.eda.kafka:
+        host: service1
+        port: 9092
+        topic: httpd-error-logs
+  rules:
+    - name: Apache shutdown triggers AI agent
+      condition: event.body.message is search("shutting down")
+      action:
+        run_job_template:
+          name: "AI Agent: Incident Response"
+          organization: "Default"
+          job_args:
+            extra_vars:
+              problem: "Apache web server (httpd) has shut down on node1."
+
+- name: AI Agent - Systemd Service Monitor
+  hosts: all
+  sources:
+    - ansible.eda.kafka:
+        host: service1
+        port: 9092
+        topic: systemd-service-logs
+  rules:
+    - name: Crond stopped triggers AI agent
+      condition: event.body.message is search("Stopped", ignorecase=true) or event.body.message is search("deactivating", ignorecase=true)
+      action:
+        run_job_template:
+          name: "AI Agent: Incident Response"
+          organization: "Default"
+          job_args:
+            extra_vars:
+              problem: >-
+                systemd service stopped on node1.
+                Event: {{ event.body.message }}


### PR DESCRIPTION
## Summary
- Removes the "Fail if service is running properly" task from `playbooks/systemd_check_status.yml`
- This task was a double-negative: it deliberately failed the playbook when httpd was already running correctly, preventing all downstream diagnostic tasks (log retrieval, set_stats) from executing
- With the fail condition removed, the playbook now runs to completion regardless of service state

## Test plan
- [ ] Run the "Apache Service Status Check" job template in AAP against a node where httpd is running — should now succeed
- [ ] Run against a node where httpd is stopped — should still collect logs and set stats as expected


Made with [Cursor](https://cursor.com)