### PR TITLE
revert: restore original Lightspeed prompt for testing

### DIFF
--- a/playbooks/network_aiops.yml
+++ b/playbooks/network_aiops.yml
@@ -11,10 +11,10 @@
        "Create a playbook and name it 'OSPF Fix'
         host ==  cisco-rtr1
         create a task that shows the status of Tunnel0 and register the output
-        run a new task using cisco.ios.ios_config with parents 'interface Tunnel0' that administratively enables interface tunnel0 when stdout contains 'administratively down', use the find method for the when condition
-        run a new task when the previous output contains 'line protocol is up' in stdout[0] using the find method, in this task do a 'show ip ospf interface tunnel0' and register as new_output
-        run a new task using cisco.ios.ios_config with parents 'interface Tunnel0' with a list of two conditionals using the find method. The first condition is output contains 'line protocol is up' in stdout[0] and second condition is when new_output doesn't contain 'Network Type POINT_TO_POINT' This task would then configure interface tunnel0 with the command 'ip ospf network type point_to_point'
-        run a new task using cisco.ios.ios_config with parents 'interface Tunnel0' with a list of three conditionals using the find method. The first condition is output contains 'line protocol is up' in stdout[0] and second condition is when new_output does contain 'Network Type POINT_TO_POINT' the third condition is when new_output doesn't contain 'Hello 10' This task would then configure interface tunnel0 with the command 'ip ospf hello-interval 10'"
+        run a new task that administratively enables interface for parent interface tunnel0 when stdout contains 'administratively down'
+        run a new task when the previous output contains 'line protocol is up' in stdout[0] in this task do a 'show ip ospf interface tunnel0' and register as new_output
+        run a new task with a list of two conditionals. The first condition is output contains 'line protocol is up' in stdout[0] and second condition is when new_output doesn't contain 'Network Type POINT_TO_POINT' This task would then configure interface tunnel0 with the command 'ip ospf network type point_to_point'
+        run a new task with a list of three conditionals. The first condition is output contains 'line protocol is up' in stdout[0] and second condition is when new_output does contain 'Network Type POINT_TO_POINT' the third condition is when new_output doesn't contain 'Hello 10' This task would then configure interface tunnel0 with the command 'ip ospf hello-interval 10'"
         
   tasks:
     - name: Include vars


### PR DESCRIPTION
Revert prompt changes to test what original prompt generates with current Lightspeed model before making targeted fixes.